### PR TITLE
feat: use brand palette for default colors

### DIFF
--- a/src/css/__tests__/__snapshots__/generate.spec.ts.snap
+++ b/src/css/__tests__/__snapshots__/generate.spec.ts.snap
@@ -1551,14 +1551,14 @@ exports[`generateCSS generate with illustrations library 1`] = `
     --g-color-infographics-axis: var(--g-color-private-black-150-solid);
     --g-color-infographics-tooltip-bg: var(--g-color-private-white-950);
 
-    --gil-color-object-base: var(--g-color-private-yellow-550-solid);
-    --gil-color-object-hightlight: var(--g-color-private-yellow-350-solid);
-    --gil-color-object-accent-heavy: var(--g-color-private-orange-650-solid);
+    --gil-color-object-base: var(--g-color-private-brand-550-solid);
+    --gil-color-object-hightlight: var(--g-color-private-brand-350-solid);
+    --gil-color-object-accent-heavy: var(--g-color-private-brand-650-solid);
     --gil-color-object-accent-light: var(--g-color-private-white-1000-solid);
     --gil-color-object-danger: var(--g-color-private-red-550-solid);
-    --gil-color-shadow-over-object: var(--g-color-private-yellow-650-solid);
-    --gil-color-background-lines: var(--g-color-private-black-450-solid);
-    --gil-color-background-shapes: var(--g-color-private-black-50-solid);
+    --gil-color-shadow-over-object: var(--g-color-private-brand-650-solid);
+    --gil-color-background-lines: var(--g-color-private-brand-650-solid);
+    --gil-color-background-shapes: var(--g-color-private-brand-100-solid);
 }
 
 .g-root_theme_dark {
@@ -1985,13 +1985,13 @@ exports[`generateCSS generate with illustrations library 1`] = `
     --g-color-infographics-axis: var(--g-color-private-white-150-solid);
     --g-color-infographics-tooltip-bg: var(--g-color-private-white-opaque-150);
 
-    --gil-color-object-base: var(--g-color-private-yellow-550-solid);
-    --gil-color-object-hightlight: var(--g-color-private-yellow-700-solid);
-    --gil-color-object-accent-heavy: var(--g-color-private-orange-650-solid);
+    --gil-color-object-base: var(--g-color-private-brand-550-solid);
+    --gil-color-object-hightlight: var(--g-color-private-brand-700-solid);
+    --gil-color-object-accent-heavy: var(--g-color-private-brand-350-solid);
     --gil-color-object-accent-light: var(--g-color-private-white-1000-solid);
     --gil-color-object-danger: var(--g-color-private-red-550-solid);
-    --gil-color-shadow-over-object: var(--g-color-private-yellow-500-solid);
-    --gil-color-background-lines: var(--g-color-private-white-550-solid);
-    --gil-color-background-shapes: var(--g-color-private-white-200-solid);
+    --gil-color-shadow-over-object: var(--g-color-private-brand-500-solid);
+    --gil-color-background-lines: var(--g-color-private-brand-650-solid);
+    --gil-color-background-shapes: var(--g-color-private-brand-200-solid);
 }"
 `;

--- a/src/json/__tests__/__snapshots__/generate.spec.ts.snap
+++ b/src/json/__tests__/__snapshots__/generate.spec.ts.snap
@@ -20085,32 +20085,32 @@ exports[`generateJSON generate with illustrations  when set reference in utility
   },
   "--gil-color-background-lines": {
     "dark": {
-      "ref": "--g-color-private-white-550-solid",
-      "value": "rgb(156 153 156)",
+      "ref": "--g-color-private-brand-650-solid",
+      "value": "",
     },
     "light": {
-      "ref": "--g-color-private-black-450-solid",
-      "value": "rgb(140 140 140)",
+      "ref": "--g-color-private-brand-650-solid",
+      "value": "",
     },
   },
   "--gil-color-background-shapes": {
     "dark": {
-      "ref": "--g-color-private-white-200-solid",
-      "value": "rgb(78 74 78)",
+      "ref": "--g-color-private-brand-200-solid",
+      "value": "",
     },
     "light": {
-      "ref": "--g-color-private-black-50-solid",
-      "value": "rgb(242 242 242)",
+      "ref": "--g-color-private-brand-100-solid",
+      "value": "",
     },
   },
   "--gil-color-object-accent-heavy": {
     "dark": {
-      "ref": "--g-color-private-orange-650-solid",
-      "value": "rgb(211 130 61)",
+      "ref": "--g-color-private-brand-350-solid",
+      "value": "",
     },
     "light": {
-      "ref": "--g-color-private-orange-650-solid",
-      "value": "rgb(211 101 7)",
+      "ref": "--g-color-private-brand-650-solid",
+      "value": "",
     },
   },
   "--gil-color-object-accent-light": {
@@ -20145,22 +20145,22 @@ exports[`generateJSON generate with illustrations  when set reference in utility
   },
   "--gil-color-object-hightlight": {
     "dark": {
-      "ref": "--g-color-private-yellow-700-solid",
-      "value": "rgb(255 210 141)",
+      "ref": "--g-color-private-brand-700-solid",
+      "value": "",
     },
     "light": {
-      "ref": "--g-color-private-yellow-350-solid",
-      "value": "rgb(255 216 157)",
+      "ref": "--g-color-private-brand-350-solid",
+      "value": "",
     },
   },
   "--gil-color-shadow-over-object": {
     "dark": {
-      "ref": "--g-color-private-yellow-500-solid",
-      "value": "rgb(233 174 86)",
+      "ref": "--g-color-private-brand-500-solid",
+      "value": "",
     },
     "light": {
-      "ref": "--g-color-private-yellow-650-solid",
-      "value": "rgb(211 158 80)",
+      "ref": "--g-color-private-brand-650-solid",
+      "value": "",
     },
   },
 }
@@ -24083,32 +24083,32 @@ exports[`generateJSON generate with illustrations library 1`] = `
   },
   "--gil-color-background-lines": {
     "dark": {
-      "ref": "--g-color-private-white-550-solid",
-      "value": "rgb(156 153 156)",
+      "ref": "--g-color-private-brand-650-solid",
+      "value": "",
     },
     "light": {
-      "ref": "--g-color-private-black-450-solid",
-      "value": "rgb(140 140 140)",
+      "ref": "--g-color-private-brand-650-solid",
+      "value": "",
     },
   },
   "--gil-color-background-shapes": {
     "dark": {
-      "ref": "--g-color-private-white-200-solid",
-      "value": "rgb(78 74 78)",
+      "ref": "--g-color-private-brand-200-solid",
+      "value": "",
     },
     "light": {
-      "ref": "--g-color-private-black-50-solid",
-      "value": "rgb(242 242 242)",
+      "ref": "--g-color-private-brand-100-solid",
+      "value": "",
     },
   },
   "--gil-color-object-accent-heavy": {
     "dark": {
-      "ref": "--g-color-private-orange-650-solid",
-      "value": "rgb(211 130 61)",
+      "ref": "--g-color-private-brand-350-solid",
+      "value": "",
     },
     "light": {
-      "ref": "--g-color-private-orange-650-solid",
-      "value": "rgb(211 101 7)",
+      "ref": "--g-color-private-brand-650-solid",
+      "value": "",
     },
   },
   "--gil-color-object-accent-light": {
@@ -24123,12 +24123,12 @@ exports[`generateJSON generate with illustrations library 1`] = `
   },
   "--gil-color-object-base": {
     "dark": {
-      "ref": "--g-color-private-yellow-550-solid",
-      "value": "rgb(255 190 92)",
+      "ref": "--g-color-private-brand-550-solid",
+      "value": "",
     },
     "light": {
-      "ref": "--g-color-private-yellow-550-solid",
-      "value": "rgb(255 190 92)",
+      "ref": "--g-color-private-brand-550-solid",
+      "value": "",
     },
   },
   "--gil-color-object-danger": {
@@ -24143,22 +24143,22 @@ exports[`generateJSON generate with illustrations library 1`] = `
   },
   "--gil-color-object-hightlight": {
     "dark": {
-      "ref": "--g-color-private-yellow-700-solid",
-      "value": "rgb(255 210 141)",
+      "ref": "--g-color-private-brand-700-solid",
+      "value": "",
     },
     "light": {
-      "ref": "--g-color-private-yellow-350-solid",
-      "value": "rgb(255 216 157)",
+      "ref": "--g-color-private-brand-350-solid",
+      "value": "",
     },
   },
   "--gil-color-shadow-over-object": {
     "dark": {
-      "ref": "--g-color-private-yellow-500-solid",
-      "value": "rgb(233 174 86)",
+      "ref": "--g-color-private-brand-500-solid",
+      "value": "",
     },
     "light": {
-      "ref": "--g-color-private-yellow-650-solid",
-      "value": "rgb(211 158 80)",
+      "ref": "--g-color-private-brand-650-solid",
+      "value": "",
     },
   },
 }

--- a/src/libraries/illustrations/constants.ts
+++ b/src/libraries/illustrations/constants.ts
@@ -3,16 +3,16 @@ import type {IllustrationColors} from './types.js';
 
 export const DEFAULT_ILLUSTRATION_COLORS: IllustrationColors = {
     'object-base': {
-        dark: {value: createInternalPrivateColorReference('yellow', '550-solid')},
-        light: {value: createInternalPrivateColorReference('yellow', '550-solid')},
+        dark: {value: createInternalPrivateColorReference('brand', '550-solid')},
+        light: {value: createInternalPrivateColorReference('brand', '550-solid')},
     },
     'object-hightlight': {
-        dark: {value: createInternalPrivateColorReference('yellow', '700-solid')},
-        light: {value: createInternalPrivateColorReference('yellow', '350-solid')},
+        dark: {value: createInternalPrivateColorReference('brand', '700-solid')},
+        light: {value: createInternalPrivateColorReference('brand', '350-solid')},
     },
     'object-accent-heavy': {
-        dark: {value: createInternalPrivateColorReference('orange', '650-solid')},
-        light: {value: createInternalPrivateColorReference('orange', '650-solid')},
+        dark: {value: createInternalPrivateColorReference('brand', '350-solid')},
+        light: {value: createInternalPrivateColorReference('brand', '650-solid')},
     },
     'object-accent-light': {
         dark: {value: createInternalPrivateColorReference('white', '1000-solid')},
@@ -23,15 +23,15 @@ export const DEFAULT_ILLUSTRATION_COLORS: IllustrationColors = {
         light: {value: createInternalPrivateColorReference('red', '550-solid')},
     },
     'shadow-over-object': {
-        dark: {value: createInternalPrivateColorReference('yellow', '500-solid')},
-        light: {value: createInternalPrivateColorReference('yellow', '650-solid')},
+        dark: {value: createInternalPrivateColorReference('brand', '500-solid')},
+        light: {value: createInternalPrivateColorReference('brand', '650-solid')},
     },
     'background-lines': {
-        dark: {value: createInternalPrivateColorReference('white', '550-solid')},
-        light: {value: createInternalPrivateColorReference('black', '450-solid')},
+        dark: {value: createInternalPrivateColorReference('brand', '650-solid')},
+        light: {value: createInternalPrivateColorReference('brand', '650-solid')},
     },
     'background-shapes': {
-        dark: {value: createInternalPrivateColorReference('white', '200-solid')},
-        light: {value: createInternalPrivateColorReference('black', '50-solid')},
+        dark: {value: createInternalPrivateColorReference('brand', '200-solid')},
+        light: {value: createInternalPrivateColorReference('brand', '100-solid')},
     },
 };


### PR DESCRIPTION
@dgaponov Hi, previously, the default illustration color tokens in DEFAULT_ILLUSTRATION_COLORS were hardcoded to specific palette colors (yellow, orange, white, black). This change replaces those hardcoded palette references with references to the brand color.